### PR TITLE
各コンテンツ向けのログイン情報クエリーを追加

### DIFF
--- a/Sample/InfraDesignSet/contents_platform.sql
+++ b/Sample/InfraDesignSet/contents_platform.sql
@@ -1,3 +1,5 @@
+
+--platform creator or developers
 CREATE TABLE developers
 ( 
   id int(10) NOT NULL PRIMARY KEY, 
@@ -7,6 +9,18 @@ CREATE TABLE developers
   updated_datetime datetime
 )
  ENGINE=INNODB;
+
+-- login information
+CREATE TABLE developer_login_temp 
+(
+  developer_id int(10) PRIMARY KEY,
+  token_information varchar(255),
+  created_datetime datetime,
+  updated_datetime datetime
+)
+ENGINE=INNODB;
+
+-- platform products
 CREATE Table develop_products
 (
   id int(10) NOT NULL PRIMARY KEY,
@@ -21,7 +35,7 @@ CREATE Table develop_products
 )
 ENGINE=INNODB;
 
-
+-- platform test device
 CREATE TABLE test_device
 (
   id int(10) NOT NULL PRIMARY KEY,

--- a/Sample/InfraDesignSet/contents_platform_query.sql
+++ b/Sample/InfraDesignSet/contents_platform_query.sql
@@ -1,22 +1,50 @@
- 
 
+#販売業者を追加
  INSERT INTO developers (id, name, active, created_datetime, updated_datetime  )
  VALUES(2, "nintendo", 1, now(), now());
 INSERT INTO developers (id, name, active, created_datetime, updated_datetime  )
  VALUES(3, "square_enix", 1, now(), now());
 
+#販売業者側でのゲーム登録フォーム画面を追加
 INSERT INTO develop_products (id, developer_id, contents_name, product_status , created_datetime, updated_datetime )
  VALUES(1, 2  , "mario jump", 1, now(), now());
+
+#登録実行確認
+select count(*) 
+from develop_products;
+
+#販売業者側でのゲーム登録フォーム画面を追加
 INSERT INTO develop_products (id, developer_id, contents_name, product_status , created_datetime, updated_datetime )
  VALUES(2, 2  , "pokemon silver", 1, now(), now());
+
+#登録実行確認
+select count(*) 
+from develop_products;
+
+#販売業者側でのゲーム登録フォーム画面を追加
 INSERT INTO develop_products (id, developer_id, contents_name, product_status , created_datetime, updated_datetime )
  VALUES(3, 3  , "FF7", 1, now(), now()); 
 
+#商品の件数を取得
+select count(*) from develop_products;
+
+#端末情報一覧を追加
 INSERT INTO test_device (id, developer_id, download_device_name, download_progress)
  VALUES(1, 2 , "ff7 debug team", 100);
 INSERT INTO test_device (id, developer_id, download_device_name, download_progress)
  VALUES(2, 2 , "ff7 smart phone team", 100);
 
+#端末情報一覧のデータ件数を追加
+select count(*) from test_device;
+
+#ログイン状態を追加
+INSERT INTO developer_login_temp ( developer_id, token_information, created_datetime, updated_datetime)
+ VALUES( 2 , "SS28N2v4", now(), now());
+
+#申請画面のログイン状況確認
+select * 
+from developer_login_temp 
+where developer_id = 1 and token_information = "";
 
 #販売業者毎のゲーム一覧を抽出 
 select developers.name,develop_products.contents_name,develop_products.product_status
@@ -28,6 +56,12 @@ select developers.name,develop_products.contents_name,develop_products.product_s
 from developers
 inner join develop_products on developers.id = develop_products.developer_id
 where develop_products.product_status = 0;
+
+#公開中のゲーム一覧を抽出(アプリ向けの一覧データ)
+select * 
+from  develop_products 
+where develop_products.product_status = 1
+limit 0, 20;
 
 #申請用画面のトップページ情報
 select *
@@ -41,5 +75,10 @@ where id = 2;
 
 #開発中のデバッグ用の端末情報一覧確認画面
 select id,developer_id,download_device_name,download_progress
+from test_device;
+
+#特定端末の詳細画面
+select *
 from test_device
+where id = 2;
 

--- a/Sample/InfraDesignSet/query.sql
+++ b/Sample/InfraDesignSet/query.sql
@@ -1,11 +1,47 @@
- 
+#管理画面アカウントを追加する
+INSERT INTO admin_user (id, name, grant_type, login_password, updated_datetime )
+ VALUES(2, "admin_master", 0, "xqgQ57Fj", now());
 
+#アカウント追加完了後の一覧情報と件数を取得
+select *
+from admin_user
+order by id;
+
+select count(*)
+from admin_user;
+
+#マスターデータのバージョン情報を追加する
 INSERT INTO master_data_ver (id, version, selected, created_datetime, updated_datetime )
  VALUES(1, "1.00", 0, now(), now());
+
+#マスターデータのバージョン情報の更新バージョンを確認するタイプ
 INSERT INTO master_data_ver (id, version, selected, created_datetime, updated_datetime )
  VALUES(2, "1.5", 1, now(), now());
 
- 
+#マスターデータのバージョン情報を取得する 
 select *
 from master_data_ver;
- 
+
+#管理画面へのログイン確認処理(パスワード忘れた場合)
+select *
+from admin_user
+where id = 1 and login_password = "fdew";
+
+#管理画面へログインできるデータパターン
+select *
+from admin_user
+where id = 2 and login_password = "xqgQ57Fj";
+
+#ログイン中セッションDB情報を追加
+INSERT INTO login_tmp (admin_user_id, token_information, created_datetime, updated_datetime )
+ VALUES(2, "kX3MNLka", now(), now());
+
+#管理画面へのログインを確認する(別ユーザーのセッションエラー)
+select *
+from login_tmp
+where admin_user_id = 1 and token_information = "kX3MNLka";
+
+#管理画面へのログインを確認する(正常確認完了ケース)
+select *
+from login_tmp
+where admin_user_id = 2 and token_information = "kX3MNLka";

--- a/Sample/InfraDesignSet/schema.sql
+++ b/Sample/InfraDesignSet/schema.sql
@@ -2,8 +2,21 @@
 CREATE TABLE admin_user 
 ( id int(10)PRIMARY KEY, 
  name varchar(255),
- grant_type int(10))
- ENGINE=INNODB;
+ grant_type int(10),
+ login_password varchar(255),
+ updated_datetime datetime
+)
+ENGINE=INNODB;
+
+-- login information
+CREATE TABLE login_tmp 
+(
+  admin_user_id int(10) PRIMARY KEY,
+  token_information varchar(255),
+  created_datetime datetime,
+  updated_datetime datetime
+)
+ENGINE=INNODB;
  
 --player_serverdb_sample
 CREATE TABLE player 
@@ -15,6 +28,7 @@ CREATE TABLE player
   updated_datetime datetime
 )
 ENGINE=INNODB;
+--player_purchase_information
 CREATE Table player_purchase
 (
   player_id int(10) NOT NULL,
@@ -25,7 +39,7 @@ CREATE Table player_purchase
   PRIMARY KEY(player_id, item_id)
 )
 ENGINE=INNODB;
-
+--master_data_version
 CREATE TABLE master_data_ver
 ( 
   id int(10) NOT NULL PRIMARY KEY, 
@@ -35,6 +49,7 @@ CREATE TABLE master_data_ver
   updated_datetime datetime
 )
  ENGINE=INNODB;
+ --store
 CREATE Table store
 (
   id int(10) NOT NULL PRIMARY KEY,


### PR DESCRIPTION
・管理画面へのアカウント追加例
・管理画面へのアカウント一覧
・マスターデータのバージョン一覧関連の説明例を追加
・ログイン中セッション情報テーブルのαを作成
・ログイン中のセッションテーブルを追加
・管理画面追加後のログインテストパターンの
SQLを追加